### PR TITLE
Update sanctuary-scripts to version 3.x

### DIFF
--- a/.config
+++ b/.config
@@ -2,3 +2,5 @@ author-name = WEAREREASONABLEPEOPLE B.V.
 repo-owner = wearereasonablepeople
 repo-name = react-collect
 source-files = index.mjs
+opening-delimiter = ```jsx
+module-type = esm

--- a/index.mjs
+++ b/index.mjs
@@ -87,7 +87,7 @@ export function createBaseCollectionManager(item) {
 //. Alternatively, for more control, you can manually use the `collect` and
 //. `uncollect` functions that are given to the decorated component as props.
 //.
-//. ```js
+//. ```jsx
 //. import {collect} from 'react-collect';
 //. import {MyComponent} from './my-component';
 //.

--- a/package.json
+++ b/package.json
@@ -33,13 +33,12 @@
   "devDependencies": {
     "coveralls": "^3.0.2",
     "esm": "^3.0.68",
-    "nyc": "^13.1.0",
     "prop-types": "^15.6.2",
     "react": "^16.4.1",
     "react-test-renderer": "^16.4.1",
     "redux": "^4.0.0",
     "rollup": "^1.0.0",
-    "sanctuary-scripts": "^2.0.0",
+    "sanctuary-scripts": "^3.2.0",
     "sanctuary-show": "^1.0.0",
     "sanctuary-type-classes": "^10.0.0",
     "sinon": "^7.1.0"

--- a/scripts/doctest
+++ b/scripts/doctest
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-echo 'Doctests cannot run on mjs files. Skipping :('

--- a/scripts/test
+++ b/scripts/test
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -euf -o pipefail
-
-source "${BASH_SOURCE%/*}/../node_modules/sanctuary-scripts/functions"
-
-branches="$(get min-branch-coverage)"
-
-node_modules/.bin/nyc --extension .mjs node_modules/.bin/mocha
-node_modules/.bin/nyc check-coverage --branches $branches


### PR DESCRIPTION
## Motivation

To keep dependencies up to date and close #12 

## Changes

- `opening-delimiter` option added to configure what sanctuary-scripts sees as code blocks
- `scripts/test` could be removed because sanctuary-scripts supports mjs files now
