### PR TITLE
Pin specific rollup version to mitigate npm bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react": "^16.4.1",
     "react-test-renderer": "^16.4.1",
     "redux": "^4.0.0",
-    "rollup": "^1.0.0",
+    "rollup": "~1.18",
     "sanctuary-scripts": "^3.2.0",
     "sanctuary-show": "^1.0.0",
     "sanctuary-type-classes": "^11.0.0",


### PR DESCRIPTION
## Motivation

Fix #18, close #17 

## Changes

There is a bug in NPM that makes [packages with peerDependencies to be incorrectly hoisted](https://npm.community/t/packages-with-peerdependencies-are-incorrectly-hoisted/4794). 

This [affects `eslint`](https://npm.community/t/failed-to-install-eslint-in-a-specific-situation/2975) when there is a package whose name is before `eslint` requiring a different version of `acorn`.

With the previous package.json we could see:

```console
$ npm ls | grep -C 3 acorn                 
├─┬ rollup@1.21.4
│ ├── @types/estree@0.0.39
│ ├── @types/node@12.7.7
│ └── acorn@7.1.0                                           <--- One version here
├─┬ sanctuary-scripts@3.2.0
│ ├─┬ doctest@0.17.1
│ │ ├── coffeescript@1.12.7
--
│ │ │ └── eslint-visitor-keys@1.1.0 deduped
│ │ ├── eslint-visitor-keys@1.1.0
│ │ ├─┬ espree@5.0.1
│ │ │ ├── acorn@6.3.0                                       <--- Another version here
│ │ │ ├── acorn-jsx@5.0.2
│ │ │ └── eslint-visitor-keys@1.1.0 deduped
│ │ ├─┬ esquery@1.0.1
```

By installing `rollup@~1.18` which [depends on `acorn@^6.2.0`](https://github.com/rollup/rollup/blob/57dd0b901aa63c6c22063b2a86ae5cf5dc3eb374/package.json#L63) we get:

```console
$ npm ls | grep -C 3 acorn
├─┬ rollup@1.18.0
│ ├── @types/estree@0.0.39
│ ├── @types/node@12.7.7
│ └── acorn@6.3.0
├─┬ sanctuary-scripts@3.2.0
│ ├─┬ doctest@0.17.1
│ │ ├── coffeescript@1.12.7
--
│ │ │ └── eslint-visitor-keys@1.1.0 deduped
│ │ ├── eslint-visitor-keys@1.1.0
│ │ ├─┬ espree@5.0.1
│ │ │ ├── acorn@6.3.0 deduped
│ │ │ ├── acorn-jsx@5.0.2
│ │ │ └── eslint-visitor-keys@1.1.0 deduped
│ │ ├─┬ esquery@1.0.1
│ │ │ └── estraverse@4.3.0 deduped
```

